### PR TITLE
update to the current version on the wordpress.org repo (0.9)

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -2,9 +2,9 @@
 Contributors: audrasjb, whodunitagency, larrach
 Donate link: https://www.paypal.me/audrasjb
 Tags: Reusable, Blocks, Gutenberg, Widget, PHP Function, Preview, Shortcode, Réutilisable, bloc, pattern, generator
-Requires at least: 5.5
-Tested up to: 5.8
-Stable tag: 0.8
+Requires at least: 5.0
+Tested up to: 6.0
+Stable tag: 0.9
 Requires PHP: 7.0
 License: GPLv2
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
@@ -67,6 +67,10 @@ Note for developers: you may also need to **get** the shortcode data **before** 
 `reblex_get_block( NUMERIC_ID_OF_THE_REUSABLE_BLOCK );`
 
 == Changelog ==
+
+= 0.9 =
+* Props @chaton666 (Marie Comet) for a small fix.
+* WP 6.0 compatibility.
 
 = 0.8 =
 * Performance enhancement on the `wp_block` list table. Props @grapplerulrich for spotting this.

--- a/reusable-blocks-extended.php
+++ b/reusable-blocks-extended.php
@@ -3,7 +3,7 @@
  * Plugin Name:	Reusable Blocks Extended
  * Plugin URI:	https://jeanbaptisteaudras.com/en/2019/09/reusable-block-extended-a-cool-wordpress-plugin-to-extend-gutenberg-reusable-block-feature/
  * Description:	Extend Gutenberg Reusable Blocks feature with a complete admin panel, widgets, shortcodes and PHP functions.
- * Version:		0.8
+ * Version:		0.9
  * Author:		audrasjb
  * Author URI:	https://jeanbaptisteaudras.com/en
  * License:		GPL-2.0+
@@ -475,7 +475,13 @@ add_filter( 'dashboard_glance_items', 'reblex_add_reusables_to_dashboard', 10, 1
  * custom_glance_items function. Register user generated patterns.
  */
 function reblex_register_block_patterns() {
+	global $pagenow;
+
 	if ( ! function_exists( 'register_block_type' ) || ! function_exists( 'register_block_pattern' ) ) {
+		return;
+	}
+
+	if ( 'media-new.php' === $pagenow || 'async-upload.php' === $pagenow ) {
 		return;
 	}
 


### PR DESCRIPTION
hello, a PR to update the repo to the same version available on wordpress.org repo : https://fr.wordpress.org/plugins/reusable-blocks-extended/

i updated this in order to eventually make some PR from the issues found here : https://wordpress.org/support/plugin/reusable-blocks-extended/

hacktoberfest time ;)